### PR TITLE
fix: don't evaluate method defs in Waluigi space, use user's module

### DIFF
--- a/src/Job.jl
+++ b/src/Job.jl
@@ -96,7 +96,7 @@ macro Job(job_description)
     target_ex = unpack_input_function(:get_target, job_name, parameter_names, target_func)
     process_ex = unpack_input_function(:run_process, job_name, parameter_names, job_features[:process], (:dependencies, :target))
     
-    struct_def = :(struct $job_name <: AbstractJob end)
+    struct_def = :(struct $job_name <: $(esc(Waluigi.AbstractJob)) end)
     push!(struct_def.args[3].args, parameter_list...)
 
     # TODO: check if there is already a struct defined that is a complete match (name, fields, types)
@@ -105,9 +105,9 @@ macro Job(job_description)
 
     return quote
         $struct_def
-        eval($(esc(dependency_ex)))
-        eval($(esc(target_ex)))
-        eval($(esc(process_ex)))
+        $(esc(dependency_ex))
+        $(esc(target_ex))
+        $(esc(process_ex))
     end
 end
 


### PR DESCRIPTION
I was originally using `Waluigi.eval` to create new definitions of the functions that need to dispatch on job type. But this was breaking precompilation in other packages. I am now using finer grained escaping so it can be evaled in the user space