### PR TITLE
Fix/more-eval-problems

### DIFF
--- a/src/Job.jl
+++ b/src/Job.jl
@@ -96,7 +96,7 @@ macro Job(job_description)
     target_ex = unpack_input_function(:get_target, job_name, parameter_names, target_func)
     process_ex = unpack_input_function(:run_process, job_name, parameter_names, job_features[:process], (:dependencies, :target))
     
-    struct_def = :(struct $job_name <: $(esc(Waluigi.AbstractJob)) end)
+    struct_def = :(struct $job_name <: Waluigi.AbstractJob end)
     push!(struct_def.args[3].args, parameter_list...)
 
     # TODO: check if there is already a struct defined that is a complete match (name, fields, types)
@@ -104,7 +104,7 @@ macro Job(job_description)
     # edit the implementation of a funciton
 
     return quote
-        $struct_def
+        $(esc(struct_def))
         $(esc(dependency_ex))
         $(esc(target_ex))
         $(esc(process_ex))

--- a/src/Job.jl
+++ b/src/Job.jl
@@ -153,13 +153,16 @@ function add_get_dep_return_type_protection(func_block)
             $func_block
         end
         corrected_deps = if t isa Nothing
-            AbstractJob[]
-        elseif t isa AbstractJob
+            Waluigi.AbstractJob[]
+        elseif t isa Waluigi.AbstractJob
             typeof(t)[t]
         elseif t isa Waluigi.AcceptableDependencyContainers
             t
+        elseif t isa Type && t <: Waluigi.AbstractJob
+            throw(ArgumentError("""The dependencies definition in $(typeof(job)) returned a AbstractJob type,\
+but dependencies must be an instance of a job. Try calling the job like `$(t)(args...)`"""))
         else
-            throw(ArgumentError("""The dependencies definition in $(typeof(job)) returned a $(typeof(t)) \
+            throw(ArgumentError("""The dependencies definition in $(typeof(job)) returned a $(t) \
 which is not one of the accepted return types. It must return one of the following: \
 <: AbstractJob, AbstractArray{<:AbstractJob}, Dict{Symbol, <:AbstractJob}"""))
         end

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -8,61 +8,74 @@ function run_pipeline(head_job)
     # Jobs is a dict id => AbstractJob
     # dep_rel is a set{Tuple{job id, dep id, satisfied}
     # job status is a dict id => bool, true means ready to run 
-    (jobs, dependancy_relations, ready_jobs) = get_dependency_details(head_job)
+    (jobs, dependency_relations, initial_ready_jobs) = get_dependency_details(head_job)
 
-    check_for_circular_dependencies(jobs, dependancy_relations)
+    check_for_circular_dependencies(jobs, dependency_relations)
 
-    results = Dict{UInt64, Dagger.EagerThunk}()
-
-    for job_id in ready_jobs
+    results = Dict{UInt64, Union{Nothing, Dagger.EagerThunk}}(
+        id => nothing
+        for id in initial_ready_jobs
+    )
+    job_id = first(initial_ready_jobs)
+    completed_all_jobs = false
+    while !completed_all_jobs
         job_deps = [
             results[dep_pair[2]]
-            for dep_pair in dependancy_relations 
+            for dep_pair in dependency_relations 
             if dep_pair[1] == job_id
         ]
 
         results[job_id] = Dagger.@spawn execute(job_id, jobs[job_id], job_deps...)
         
         # Find upstream jobs and check if completing this job makes them ready for execution
-        upstream_jobs = dependancy_relations |>
+        upstream_jobs = dependency_relations |>
                 # get jobs that depend on the completed job
                 ((dr) -> Iterators.filter((p) -> p[2] == job_id, dr)) .|>
                 # Set "satisfied" field to true
-                ((p) -> (delete!(dependancy_relations, p); p)) .|>
-                ((p) -> (push!(dependancy_relations, (p[1], p[2], true)); p[1])) 
+                ((p) -> (delete!(dependency_relations, p); p)) .|>
+                ((p) -> (push!(dependency_relations, (p[1], p[2], true)); p[1])) 
                 
         for upstream in upstream_jobs
             is_unsatsifed_match_flag = Iterators.map(
                 (rel) -> rel[1] == upstream && !rel[3], 
-                dependancy_relations
+                dependency_relations
                 )
             upstream_ready = !any(is_unsatsifed_match_flag)
             if upstream_ready
-                push!(ready_jobs, upstream)
+                results[upstream] = nothing
             end
         end
-    end
 
+        job_id = findfirst(p -> p[2] === nothing, (p for p in pairs(results)))
+        
+        if job_id === nothing
+            completed_all_jobs = true
+        end
+    end
     results[hash(head_job)]
 end
 
 
 function get_dependency_details(head_job)
+    println("get_dependency_details is changed")
     # The look up for the actual job objects
     jobs = Dict{UInt64, AbstractJob}()
     # Tracking if a job is ready to run
     ready_jobs = Set{UInt64}()
-    dep_relations = Set{Tuple{UInt64,UInt64,Bool}}()
+    dep_relations = Dict{Tuple{UInt64,UInt64,Bool}, Int}()
     traverse_dependencies!(head_job, jobs, dep_relations, ready_jobs)
-    return (jobs = jobs, dependancy_relations = dep_relations, ready_jobs = ready_jobs)
+    return (jobs = jobs, dependency_relations = dep_relations, ready_jobs = ready_jobs)
 end
 
-function traverse_dependencies!(job, jobs, dep_relations, ready_jobs)
+function traverse_dependencies!(job, jobs, dep_relations, ready_jobs, depth = 1)
+    job_id = hash(job)
+    if depth > 100
+        return job_id
+    end
     # We need to get the dependencies as a vector (get values of dicts)
     dep_container = get_dependencies(job)
     dep_list = get_dependencies_list(dep_container)
 
-    job_id = hash(job)
     
     # Jobs with no dependencies are ready to run
     if isempty(dep_list)
@@ -71,36 +84,61 @@ function traverse_dependencies!(job, jobs, dep_relations, ready_jobs)
 
     jobs[job_id] = job
 
-    # Go get grandchild dependancy information
+    # Go get grandchild dependency information
     for dep in dep_list
-        dep_id = traverse_dependencies!(dep, jobs, dep_relations, ready_jobs)
-        push!(dep_relations, (job_id, dep_id, false))
+        dep_id = traverse_dependencies!(dep, jobs, dep_relations, ready_jobs, depth + 1)
+        dependency = (job_id, dep_id, false)
+        relation_occurances = get(dep_relations, dependency, 0) + 1
+        dep_relations[(job_id, dep_id, false)] = relation_occurances
+        if relation_occurances > 25
+            check_for_circular_dependencies(jobs, keys(dep_relations))
+        end
     end
 
     return job_id
 end
 
-get_dependencies_list(deps::AbstractDict) = collect(values(deps))
+get_dependencies_list(deps::AbstractDict{Symbol, AbstractJob}) = collect(values(deps))
+get_dependencies_list(::Nothing) = AbstractJob[]
 get_dependencies_list(deps) = deps
 
-function check_for_circular_dependencies(jobs, dependancy_relations)
+function check_for_circular_dependencies(jobs, dependency_relations)
+
+    # SimpleDiGraph only uses OneTo Ints as IDs so we need a map back to job ids
     job_id_to_idx = Dict(
         job_id => i
         for (i, job_id) in enumerate(keys(jobs))
     )
 
-    g = SimpleDiGraph{UInt64}(length(keys(jobs)))
+    g = SimpleDiGraph(length(keys(jobs)))
 
-    for (job_id, dep_id, _) in dependancy_relations
+    for (job_id, dep_id, _) in dependency_relations
         job_idx = job_id_to_idx[job_id]
         dep_idx = job_id_to_idx[dep_id]
         add_edge!(g, job_idx, dep_idx)
     end
 
-    cycles = Graphs.simplecycles_iter(g, 1)
+    cycles = Graphs.simplecycles_iter(g)
 
-    if length(cycles) > 1
-        throw(ArgumentError("The dependency tree contains cycles. Please resolve."))
+    # Build a clean looking printout for the dependency cycle error
+    if length(cycles) >= 1
+        cycle_explanation = Vector{String}(undef, length(cycles) + sum(length.(cycles)))
+        explain_idx = 1
+        for (i, cycle) in enumerate(cycles)
+            cycle_explanation[explain_idx] = "Cycle Number $i\n"
+            explain_idx += 1
+            for ci in eachindex(cycle)
+                job_idx = cycle[ci]
+                dep_idx = cycle[(ci)%length(cycle) + 1]
+                job_id = findfirst(p -> p[2]==job_idx, (p for p in pairs(job_id_to_idx)))[1]
+                dep_id = findfirst(p -> p[2]==dep_idx, (p for p in pairs(job_id_to_idx)))[1]
+                job = jobs[job_id]
+                dep = jobs[dep_id]
+                cycle_explanation[explain_idx] = "\tDependency Pair$ci\n\t\t$job\n\t\t$dep\n"
+                explain_idx += 1
+            end
+        end
+        throw(InvalidStateException("The dependency tree contains cycles. Please resolve.\n" * foldl(*, cycle_explanation), :CyclicalDependency))
     end
 
 end

--- a/src/Pipeline.jl
+++ b/src/Pipeline.jl
@@ -10,8 +10,6 @@ function run_pipeline(head_job)
     # job status is a dict id => bool, true means ready to run 
     (jobs, dependency_relations, initial_ready_jobs) = get_dependency_details(head_job)
 
-    check_for_circular_dependencies(jobs, dependency_relations)
-
     results = Dict{UInt64, Union{Nothing, Dagger.EagerThunk}}(
         id => nothing
         for id in initial_ready_jobs
@@ -47,7 +45,6 @@ function run_pipeline(head_job)
         end
 
         job_id = findfirst(p -> p[2] === nothing, (p for p in pairs(results)))
-        
         if job_id === nothing
             completed_all_jobs = true
         end
@@ -57,13 +54,13 @@ end
 
 
 function get_dependency_details(head_job)
-    println("get_dependency_details is changed")
     # The look up for the actual job objects
     jobs = Dict{UInt64, AbstractJob}()
     # Tracking if a job is ready to run
     ready_jobs = Set{UInt64}()
     dep_relations = Dict{Tuple{UInt64,UInt64,Bool}, Int}()
     traverse_dependencies!(head_job, jobs, dep_relations, ready_jobs)
+    dep_relations = Set(keys(dep_relations))
     return (jobs = jobs, dependency_relations = dep_relations, ready_jobs = ready_jobs)
 end
 

--- a/src/Waluigi.jl
+++ b/src/Waluigi.jl
@@ -3,7 +3,7 @@ module Waluigi
 using Dagger
 using Graphs
 
-export @Job, AbstractJob, get_dependencies, get_target, get_result, run_process, execute
+export @Job, get_dependencies, get_target, get_result, execute, run_process
 
 include("Target.jl")
 include("Job.jl")

--- a/test/test_jobs.jl
+++ b/test/test_jobs.jl
@@ -30,7 +30,7 @@ Waluigi.@Job begin
     dependencies = [DepJob(2,4)]
     target = nothing
     process = begin
-        sum_dep = get_result(dependencies[1])
+        sum_dep = Waluigi.get_result(dependencies[1])
         return sum_dep + 1
     end
 end
@@ -99,6 +99,13 @@ end
 Waluigi.@Job begin
     name = ReturnDepTypeNotInstance
     dependencies = DepJob
+end
+
+struct TesterType end
+Waluigi.@Job begin
+    name = IUseTesterType
+    parameters = (a::TesterType,)
+    process = true
 end
 
 end # TestJobs Module

--- a/test/test_jobs.jl
+++ b/test/test_jobs.jl
@@ -1,7 +1,8 @@
 module TestJobs
 
-using Waluigi
-@Job begin
+import ..Waluigi
+
+Waluigi.@Job begin
     name = NothingJob
     parameters = nothing
     dependencies = nothing
@@ -9,11 +10,11 @@ using Waluigi
     process = nothing
 end
 
-@Job begin
+Waluigi.@Job begin
     name = OopsAllOmited
 end
 
-@Job begin
+Waluigi.@Job begin
     name = DepJob
     parameters = (a,b)
     dependencies = nothing
@@ -23,7 +24,7 @@ end
     end
 end
 
-@Job begin
+Waluigi.@Job begin
     name = MainJob
     parameters = nothing
     dependencies = [DepJob(2,4)]
@@ -34,7 +35,7 @@ end
     end
 end
 
-@Job begin
+Waluigi.@Job begin
     name = BadDeps
     parameters = nothing
     dependencies = (a = DepJob(2,4),)
@@ -42,7 +43,7 @@ end
     process = nothing
 end
 
-@Job begin
+Waluigi.@Job begin
     name = BadTarget
     parameters = nothing
     dependencies = nothing
@@ -50,7 +51,7 @@ end
     process = nothing
 end
 
-@Job begin
+Waluigi.@Job begin
     name = CheckPointTester
     parameters = (a,)
     dependencies = nothing
@@ -58,7 +59,7 @@ end
     process = a
 end
 
-@Job begin
+Waluigi.@Job begin
     name = UsingCustomTarget
     parameters = (tbl, parq_dir)
     dependencies = nothing
@@ -66,7 +67,7 @@ end
     process = tbl
 end
 
-@Job begin
+Waluigi.@Job begin
     name = TypedParams
     parameters = (a::Int, b::String)
     dependencies = nothing
@@ -74,7 +75,7 @@ end
     process = nothing
 end
 
-@Job begin
+Waluigi.@Job begin
     name = UsingTypedParams
     parameters = (a::Int, b::String)
     dependencies = nothing
@@ -85,14 +86,19 @@ end
     end
 end
 
-@Job begin
+Waluigi.@Job begin
     name = CycleDepA
-    dependencies = CycleDepB
+    dependencies = CycleDepB()
 end
 
-@Job begin
+Waluigi.@Job begin
     name = CycleDepB
-    dependencies = CycleDepA
+    dependencies = CycleDepA()
+end
+
+Waluigi.@Job begin
+    name = ReturnDepTypeNotInstance
+    dependencies = DepJob
 end
 
 end # TestJobs Module


### PR DESCRIPTION
Resolved:
- Dependency cycles weren't detected during the graph creation process, causing overflow
- Less convoluted tracking system for blocked, ready, and completed jobs
- user defined types weren't being escaped properly