### PR TITLE
Issue-14: Revise custom target test to use txt file

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-Parquet2 = "98572fba-bba0-415d-956f-fa77e587d26d"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,19 +80,15 @@ end
     rm(checkpoint_fp)
 
     # Checkpoint with custom target, same strategy as above
-    test_parq_dir = joinpath(test_files, "test_parq_dir")
-    parq_file = joinpath(test_parq_dir, "1.parq")
-    rm(test_parq_dir; force=true, recursive=true)
-    @test !isdir(test_parq_dir)
-    df_1 = DataFrame(a=[1,2,3], b=["a","b","c"])
-    use_custom_1 = TestJobs.UsingCustomTarget(df_1, test_parq_dir)
-    @test df_1 == (Waluigi.run_pipeline(use_custom_1) |> get_result |> DataFrame)
-    @test isfile(parq_file)
-
-    df_2 = DataFrame(e=[1,1,1])
-    use_custom_2 = TestJobs.UsingCustomTarget(df_2, test_parq_dir)
-    @test df_1 == (Waluigi.run_pipeline(use_custom_2) |> get_result |> DataFrame)
-    rm(test_parq_dir; force=true, recursive=true)
+    test_text_dir = joinpath(test_files, "test_text_dir")
+    text_file = joinpath(test_text_dir, "1.txt")
+    rm(test_text_dir; force=true, recursive=true)
+    @test !isdir(test_text_dir)
+    waluigi_quote = "Good Choice!"
+    use_custom_1 = TestJobs.UsingCustomTarget("Good Choice!", test_text_dir)
+    @test waluigi_quote == Waluigi.run_pipeline(use_custom_1) |> get_result
+    @test isfile(text_file)
+    rm(test_text_dir; force=true, recursive=true)
 end
 
 @testset "Typing Parameters" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ end
 __init__()
 
 using Test
-using DataFrames
 using Dagger
 using Waluigi
 

--- a/test/test_jobs.jl
+++ b/test/test_jobs.jl
@@ -61,10 +61,10 @@ end
 
 Waluigi.@Job begin
     name = UsingCustomTarget
-    parameters = (tbl, parq_dir)
+    parameters = (str, text_dir)
     dependencies = nothing
-    target = Main.ParquetDirTarget(parq_dir; read_kwargs = (use_mmap=false,))
-    process = tbl
+    target = Main.TextDirTarget(text_dir)
+    process = str
 end
 
 Waluigi.@Job begin


### PR DESCRIPTION
Revise customer target test to use text file removing dependency for DataFrames and Parquet2. Checkpointing tests dropped from 20 sec to about 2 sec.